### PR TITLE
Add basic styling and Codearea component

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
+    "css-loader": "0.23.1",
+    "style-loader": "0.13.1",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
     "react": "15.1.0",
+    "react-codemirror": "0.2.6",
     "react-dom": "15.1.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Codearea from './components/Codearea.jsx'
+import './base.css'
 
 class App extends React.Component {
     render() {

--- a/src/base.css
+++ b/src/base.css
@@ -1,0 +1,59 @@
+body {
+  background: #fff;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.7;
+  margin: 0;
+  padding: 30px;
+}
+
+a {
+  color: #4183c4;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  font-family: "Bitstream Vera Sans Mono", Consolas, Courier, monospace;
+  font-size: 12px;
+  margin: 0 2px;
+  padding: 0 5px;
+}
+
+h1, h2, h3, h4 {
+  font-weight: bold;
+  margin: 0 0 15px;
+  padding: 0;
+}
+
+h1 {
+  border-bottom: 1px solid #ddd;
+  font-size: 2.5em;
+}
+
+h2 {
+  border-bottom: 1px solid #eee;
+  font-size: 2em;
+}
+
+h3 {
+  font-size: 1.5em;
+}
+
+h4 {
+  font-size: 1.2em;
+}
+
+p, ul {
+  margin: 15px 0;
+}
+
+ul {
+  padding-left: 30px;
+}

--- a/src/components/Codearea.jsx
+++ b/src/components/Codearea.jsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Codemirror from 'react-codemirror';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/theme/material.css';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/keymap/sublime.js'
+
+class Codearea extends React.Component {
+   constructor() {
+      super();
+
+      this.state = {
+        consoleContent: '',
+        errorContent: '',
+        resizing: false
+      };
+
+      this.updateCode = this.updateCode.bind(this);
+      this.runCode = this.runCode.bind(this);
+      this.startResize = this.startResize.bind(this);
+      this.resize = this.resize.bind(this);
+   }
+
+   componentDidMount() {
+      this.editorNode = ReactDOM.findDOMNode(this.editor);
+      this.bottomBoxNode = ReactDOM.findDOMNode(this.bottomBox);
+
+      this.editorNode.style.width = this.props.console ? 'calc(50% - ' + this.props.resizeDividerWidth / 2 + 'px)' : '100%';
+      this.bottomBoxNode.style.width = this.editorNode.style.width;
+
+      this.editorNode.querySelector('.CodeMirror').style.height = 'calc(100% - ' + this.props.bottomBoxHeight + 'px)';
+      this.bottomBoxNode.style.height = this.props.bottomBoxHeight + 'px';
+   }
+
+   updateCode(newCode) {
+      this.setState({code: newCode});
+      this.props.onChange(newCode);
+   }
+
+   runCode() {
+      const code = this.state.code;
+      const oldConsole = window.console;
+      let consoleContent = '';
+      let errorContent = '';
+
+      function addToConsoleContent(args) {
+         if(consoleContent) {
+            consoleContent += '\n';
+         }
+         for(let i = 0; i < args.length; i++) {
+            consoleContent += args[i] + ' ';
+         }
+      }
+
+      function addToErrorContent(args) {
+         if(errorContent) {
+            errorContent += '\n';
+         }
+         for(let i = 0; i < args.length; i++) {
+            errorContent += args[i] + ' ';
+         }
+      }
+
+      window.console = {
+         log: function() {
+            addToConsoleContent(arguments);
+         },
+         error: function() {
+            addToErrorContent(arguments);
+         },
+         dir: function() {
+            addToConsoleContent(arguments);
+         },
+         warn: function() {
+            addToConsoleContent(arguments);
+         },
+         info: function() {
+            addToConsoleContent(arguments);
+         },
+         debug: function() {
+            addToConsoleContent(arguments);
+         }
+      };
+
+      try {
+         eval(code);
+      } catch(error) {
+         console.error(error);
+      }
+
+      this.setState({consoleContent, errorContent});
+      window.console = oldConsole;
+      this.props.onSubmit(code);
+   }
+
+   startResize() {
+      this.setState({resizing: true});
+      const handleMouseUp = function() {
+         window.removeEventListener('mouseup', handleMouseUp);
+         this.setState({resizing: false});
+      }.bind(this);
+      window.addEventListener('mouseup', handleMouseUp);
+   }
+
+   resize(e) {
+      const overlayRect = e.target.getBoundingClientRect();
+      const offsetLeft = e.clientX - overlayRect.left;
+      const newEditorWidth = e.clientX - overlayRect.left - this.props.resizeDividerWidth / 2;
+      if(newEditorWidth >= this.props.componentMinWidth &&
+         newEditorWidth <= overlayRect.width - this.props.componentMinWidth - this.props.resizeDividerWidth) {
+         this.editorNode.style.width = newEditorWidth + 'px';
+         this.bottomBoxNode.style.width = this.editorNode.style.width;
+      }
+   }
+
+   render() {
+      const codemirrorOptions = {
+         mode: 'javascript',
+         lineNumbers: true,
+         theme: 'material',
+         indentUnit: 4,
+         keyMap: 'sublime',
+         lineWrapping: true
+      };
+
+      let style = {
+         height: '300px',
+         border: '1px solid #d9d9d9',
+         position: 'relative',
+         display: 'flex'
+      };
+
+      Object.assign(style, this.props.style);
+
+      const bottomBoxStyle = {
+         display: 'flex',
+         position: 'absolute',
+         left: '0px',
+         bottom: '0px'
+      };
+
+      return (
+         <div style={style}>
+            <ResizeOverlay
+               onResize={this.resize}
+               visible={this.state.resizing}/>
+            <Codemirror
+               ref={(c) => this.editor = c}
+               value={this.state.code}
+               onChange={this.updateCode}
+               options={codemirrorOptions}/>
+            <div
+               ref={(c) => this.bottomBox = c}
+               style={bottomBoxStyle}>
+               <ErrorBox content={this.state.errorContent}/>
+               <RunCodeButton handleRunCode={this.runCode}/>
+            </div>
+            <ResizeDivider
+               width={this.props.resizeDividerWidth}
+               onResizeStart={this.startResize}
+               visible={this.props.console}/>
+            <Console
+               visible={this.props.console}
+               content={this.state.consoleContent}/>
+         </div>
+      );
+   }
+}
+
+Codearea.defaultProps = {
+   console: true,
+   resizeDividerWidth: 5,
+   componentMinWidth: 100,
+   bottomBoxHeight: 38,
+   onChange: () => {},
+   onSubmit: () => {}
+};
+
+class RunCodeButton extends React.Component {
+   constructor() {
+      super();
+
+      this.state = {
+         hover: false,
+         active: false
+      };
+
+      this.startHover = this.startHover.bind(this);
+      this.stopHover = this.stopHover.bind(this);
+      this.startClick = this.startClick.bind(this);
+      this.stopClick = this.stopClick.bind(this);
+   }
+
+   startHover() {
+      this.setState({hover: true});
+   }
+
+   stopHover() {
+      this.setState({hover: false});
+   }
+
+   startClick() {
+      this.setState({active: true});
+   }
+
+   stopClick() {
+      this.setState({active: false});
+   }
+
+   render() {
+      const style = {
+         background: this.state.active ? '#e1e1e1' : this.state.hover ? '#e6e6e6' : '#f0f0f0',
+         border: 'none',
+         borderLeft: '1px solid #d9d9d9',
+         outline: 'none',
+         userSelect: 'none',
+         color: '#222'
+      };
+
+      return (
+         <button
+            style={style}
+            onClick={this.props.handleRunCode}
+            onMouseEnter={this.startHover}
+            onMouseLeave={this.stopHover}
+            onMouseDown={this.startClick}
+            onMouseUp={this.stopClick}>
+            Run code
+         </button>
+      );
+   }
+}
+
+class ErrorBox extends React.Component {
+   render() {
+      const style = {
+         resize: 'none',
+         outline: 'none',
+         border: 'none',
+         padding: '10px',
+         fontSize: '14px',
+         background: '#fafafa',
+         color: '#b30000',
+         flex: '1'
+      };
+
+      return (
+         <textarea
+            style={style}
+            readOnly
+            value={this.props.content}>
+         </textarea>
+      );
+   }
+}
+
+class Console extends React.Component {
+   render() {
+      const style = {
+         resize: 'none',
+         outline: 'none',
+         border: 'none',
+         display: this.props.visible ? 'inline-block' : 'none',
+         flex: '1',
+         padding: '10px',
+         fontSize: '14px',
+         background: '#fafafa'
+      };
+
+      return (
+         <textarea
+            style={style}
+            readOnly
+            value={this.props.content}>
+         </textarea>
+      );
+   }
+}
+
+class ResizeDivider extends React.Component {
+   render() {
+      const dividerStyle = {
+         width: this.props.width + 'px',
+         cursor: 'ew-resize',
+         boxSizing: 'border-box',
+         background: '#d0d0d0',
+         display: this.props.visible ? 'flex' : 'none',
+         justifyContent: 'center'
+      };
+
+      const grabberStyle = {
+         background: '#888',
+         width: Math.floor(this.props.width / 2) + 'px',
+         height: '12px',
+         borderRadius: this.props.width / 2 + 'px',
+         alignSelf: 'center'
+      };
+
+      return (
+         <div style={dividerStyle} onMouseDown={this.props.onResizeStart}>
+            <div style={grabberStyle}></div>
+         </div>
+      );
+   }
+}
+
+class ResizeOverlay extends React.Component {
+   render() {
+      const style = {
+         width: '100%',
+         height: '100%',
+         display: (this.props.visible ? 'block' : 'none'),
+         position: 'absolute',
+         zIndex: '5',
+         cursor: 'ew-resize'
+      };
+
+      return (
+         <div style={style} onMouseMove={this.props.onResize}></div>
+      );
+   }
+}
+
+export default Codearea;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,10 @@ var config = {
                 query: {
                     presets: ['es2015', 'react']
                 }
+            },
+            {
+                test: /\.css$/,
+                loader: "style-loader!css-loader"
             }
         ]
     }


### PR DESCRIPTION
![screen shot 2016-06-21 at 13 48 39](https://cloud.githubusercontent.com/assets/9382144/16228359/d62f944e-37b6-11e6-8377-53e160697a3c.png)
![screen shot 2016-06-21 at 13 49 03](https://cloud.githubusercontent.com/assets/9382144/16228360/d8a4020a-37b6-11e6-9035-e7904ea554df.png)

The size of the editor can be resized by dragging the divider between the editor and the console.

The console can be completely disabled by adding the property console={false} to the Codearea component. Other changeable properties are: resizeDividerWidth (sets the width of the divider between the console and the editor), componentMinWidth (sets the min width of the editor and the console), bottomBoxHeight (sets the height of the error console and the run code button).

You can access the code with the onChange and onSubmit event callbacks. 
