### PR TITLE
Add resizer component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Markdown from './components/Markdown.jsx';
 import PageSelector from './components/PageSelector.jsx';
 import {serverUrl, pageTitle} from './constants.js';
 import guidePages from './pages.json';
+import Resizer from './components/Resizer.jsx';
 import './base.css';
 
 class App extends React.Component {
@@ -76,7 +77,8 @@ class App extends React.Component {
         };
 
         const playgroundStyle = {
-            flex: '1'
+            flex: '1',
+            overflow: 'auto'
         };
 
         const guidePageWrapperStyle = {
@@ -106,6 +108,7 @@ class App extends React.Component {
                             onGoToPrevPage={this.goToPrevPage}
                             onGoToNextPage={this.goToNextPage}/>
                     </div>
+                    <Resizer elementMinSize={200}/>
                     <Playground
                         style={playgroundStyle}
                         code={require(`raw!./${guidePages[`page${this.state.currentPage}`].code}`)}

--- a/src/components/Resizer.jsx
+++ b/src/components/Resizer.jsx
@@ -9,27 +9,34 @@ class Resizer extends React.Component {
             directionColumn: false
         };
 
+        this.resizeHandler = this.resizeHandler.bind(this);
         this.nodeCreated = this.nodeCreated.bind(this);
     }
 
     nodeCreated(node) {
-        this.node = node;
         this.prevNode = node.previousSibling;
         this.nextNode = node.nextSibling;
         this.parentNode = node.parentNode;
+
         const directionColumn = this.parentNode.style.flexDirection === 'column';
         this.setState({directionColumn});
 
-        window.addEventListener('resize', () => {
-            const prevNodeRect = this.prevNode.getBoundingClientRect();
-            const nextNodeRect = this.nextNode.getBoundingClientRect();
-            const prevNodeSize = directionColumn ? prevNodeRect.height : prevNodeRect.width;
-            const nextNodeSize = directionColumn ? nextNodeRect.height : nextNodeRect.width;
+        window.addEventListener('resize', this.resizeHandler);
+    }
 
-            if(prevNodeSize < this.props.elementMinSize || nextNodeSize < this.props.elementMinSize) {
-                this.prevNode.style.flex = '1';
-            }
-        });
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.resizeHandler);
+    }
+
+    resizeHandler() {
+        const prevNodeRect = this.prevNode.getBoundingClientRect();
+        const nextNodeRect = this.nextNode.getBoundingClientRect();
+        const prevNodeSize = this.state.directionColumn ? prevNodeRect.height : prevNodeRect.width;
+        const nextNodeSize = this.state.directionColumn ? nextNodeRect.height : nextNodeRect.width;
+
+        if(prevNodeSize < this.props.elementMinSize || nextNodeSize < this.props.elementMinSize) {
+            this.prevNode.style.flex = '1';
+        }
     }
 
     startResize() {

--- a/src/components/Resizer.jsx
+++ b/src/components/Resizer.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import {defaultBorderColor} from '../constants.js';
+
+class Resizer extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            directionColumn: false
+        };
+
+        this.nodeCreated = this.nodeCreated.bind(this);
+    }
+
+    nodeCreated(node) {
+        this.node = node;
+        this.prevNode = node.previousSibling;
+        this.nextNode = node.nextSibling;
+        this.parentNode = node.parentNode;
+        const directionColumn = this.parentNode.style.flexDirection === 'column';
+        this.setState({directionColumn});
+
+        window.addEventListener('resize', () => {
+            const prevNodeRect = this.prevNode.getBoundingClientRect();
+            const nextNodeRect = this.nextNode.getBoundingClientRect();
+            const prevNodeSize = directionColumn ? prevNodeRect.height : prevNodeRect.width;
+            const nextNodeSize = directionColumn ? nextNodeRect.height : nextNodeRect.width;
+
+            if(prevNodeSize < this.props.elementMinSize || nextNodeSize < this.props.elementMinSize) {
+                this.prevNode.style.flex = '1';
+            }
+        });
+    }
+
+    startResize() {
+        const directionColumn = this.state.directionColumn;
+        const size = this.props.size;
+        const elementMinSize = this.props.elementMinSize;
+        const defaultCursor = document.body.style.cursor;
+        const prevNodeRect = this.prevNode.getBoundingClientRect();
+        const parentNodeRect = this.parentNode.getBoundingClientRect();
+
+        document.body.style.cursor = directionColumn ? 'ns-resize' : 'ew-resize';
+
+        const handleMouseMove = e => {
+            e.preventDefault();
+            window.getSelection().removeAllRanges();
+
+            const parentNodeSize = directionColumn ? parentNodeRect.height : parentNodeRect.width;
+            let newPrevNodeSize = (directionColumn ? e.clientY - prevNodeRect.top : e.clientX - prevNodeRect.left) - size / 2;
+            const newNextNodeSize = parentNodeSize - size - newPrevNodeSize;
+
+            if(newPrevNodeSize >= elementMinSize) {
+                if(newNextNodeSize < elementMinSize) {
+                    newPrevNodeSize = parentNodeSize - size - elementMinSize;
+                }
+            } else {
+                newPrevNodeSize = elementMinSize;
+            }
+
+            this.prevNode.style.flex = `0 0 ${newPrevNodeSize}px`;
+        }
+
+        const handleMouseUp = () => {
+            window.removeEventListener('mouseup', handleMouseUp);
+            window.removeEventListener('mousemove', handleMouseMove);
+            document.body.style.cursor = defaultCursor;
+        }
+
+        window.addEventListener('mousemove', handleMouseMove);
+        window.addEventListener('mouseup', handleMouseUp);
+    }
+
+    render() {
+        const style = {
+            minWidth: this.props.size,
+            minHeight: this.props.size,
+            background: defaultBorderColor,
+            cursor: this.state.directionColumn ? 'ns-resize' : 'ew-resize'
+        };
+
+        return (
+            <div
+                onMouseDown={this.startResize.bind(this)}
+                ref={this.nodeCreated}
+                style={style}/>
+        );
+    }
+}
+
+Resizer.defaultProps = {
+    size: 5,
+    elementMinSize: 100
+}
+
+export default Resizer;


### PR DESCRIPTION
You can now resize the editor area and the text area by dragging the resizer between them. The resizer only works if it's surrounded by two `flex: 1` items within a `display: flex/inline-flex` container. It works both for `flex-direction: column` and `flex-direction: row` on the container. All you are required to do is to add the <Resizer/> component between the items you want to resize. User-changeable options are: `elementMinSize` which sets the minimum size (width or height depending on column or row container) of the elements that are going to be resized, and `size` which sets the width or height of the resizer.

![untitled](https://cloud.githubusercontent.com/assets/9382144/16682449/0a3d5946-44fb-11e6-9803-38cfbbe1b092.gif)
